### PR TITLE
feat: fischauswahl am frontend bereitstellen

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,6 +2,7 @@ from flask import Flask  # Flask-Framework importieren, um die Webanwendung zu e
 from flask_cors import CORS  # CORS (Cross-Origin Resource Sharing) importieren, um externe Anfragen zuzulassen
 from catch import catch_blueprint  # Blueprint "catch" importieren, um modularen Code zu verwenden
 from history import history_blueprint  # Blueprint "history" importieren, um modularen Code zu verwenden
+from fish import fish_blueprint  # Blueprint "fish" importieren, um modularen Code zu verwenden
 
 # Erstelle eine Flask-App-Instanz
 app = Flask(__name__)
@@ -12,6 +13,7 @@ CORS(app)
 # Blueprint registrieren, um Routen und Logik aus der "catch","history"-Komponente modular hinzuzufügen
 app.register_blueprint(catch_blueprint)
 app.register_blueprint(history_blueprint)
+app.register_blueprint(fish_blueprint)
 
 # Route für die Startseite definieren
 @app.route('/')

--- a/backend/fish.py
+++ b/backend/fish.py
@@ -1,0 +1,19 @@
+from flask import Blueprint, jsonify
+import sqlite3
+
+fish_blueprint = Blueprint('fish', __name__)
+
+def get_db_connection():
+    conn = sqlite3.connect('fischerfritz.db')
+    conn.row_factory = sqlite3.Row
+    return conn
+
+@fish_blueprint.route('/fish', methods=['GET'])
+def get_fish_names():
+    try:
+        conn = get_db_connection()
+        fish_names = conn.execute("SELECT name FROM fish").fetchall()
+        conn.close()
+        return jsonify([fish['name'] for fish in fish_names]), 200
+    except sqlite3.Error as e:
+        return jsonify({"error": "Database error", "details": str(e)}), 500

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -142,6 +142,36 @@ async function saveCatch(event) {
   }
 }
 
+// Funktion: Fischnamen vom Backend aus der Tabelle Fish laden und im Formular anzeigen
+async function loadFishNames() {
+  const dropdown = document.getElementById("fish");
+
+  try {
+    // Abrufen der Fischnamen vom Backend
+    const response = await fetch("http://127.0.0.1:5000/fish");
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+
+    const fishNames = await response.json();
+
+    // Dropdown-Menü leeren und mit Optionen füllen
+    dropdown.innerHTML = '<option value="" disabled selected>Wähle einen Fisch</option>';
+    fishNames.forEach((fishName) => {
+      const option = document.createElement("option");
+      option.value = fishName; // Der Wert der Option
+      option.textContent = fishName; // Der angezeigte Text
+      dropdown.appendChild(option);
+    });
+  } catch (error) {
+    console.error("Fehler beim Laden der Fischnamen:", error);
+    dropdown.innerHTML = '<option value="" disabled>Fischnamen konnten nicht geladen werden</option>';
+  }
+}
+
+// Event-Listener: Fische laden, wenn die Seite geladen wird
+document.addEventListener("DOMContentLoaded", loadFishNames);
+
 // Funktion, um die Uhrzeit ins Formular zu setzen
 function setCurrentTime() {
     const timeInput = document.getElementById("time");

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -48,12 +48,11 @@
         <form id="fishCatchForm">
           <div class="mb-3">
             <label for="fishName" class="form-label">Fischname</label>
-            <div class="input-group">
-              <input type="text" class="form-control" id="fish" placeholder="Fischname">
-              <input type="text" id="fishid" hidden>
-            </div>
+              <select class="form-control" id="fish">
+                <option value="" disabled selected>Wähle den gefangenen Fisch</option>
+                <input type="text" id="fishid" hidden>
+              </select>
           </div>
-
           <div class="mb-3">
             <label class="form-label">Standort/Gewässer</label>
             <div class="input-group">
@@ -76,6 +75,10 @@
             <div class="col-md-6 mb-3">
               <label for="weight" class="form-label">Gewicht (kg)</label>
               <input type="text" class="form-control" id="weight" placeholder="(kg)">
+            </div>
+            <div class="col-md-6 mb-3">
+              <label for="length" class="form-label">Länge (cm)</label>
+              <input type="text" class="form-control" id="length" placeholder="(cm)">
             </div>
           </div>
           <button type="submit" class="btn btn-primary" onclick="saveCatch()">Speichern</button>


### PR DESCRIPTION
Erweiterung um fish endpoint, mittels GET Operation können alle in der Tabelle Fish exisitierenden Fishe für das Frontend auswählbar gemacht werden. Somit können nur bekannte Fische gefangen werden. Fehler werden somit minimiert.